### PR TITLE
Fixed Bug

### DIFF
--- a/app/src/main/java/com/convergencelabstfx/smartdrone/Utility/DroneLog.java
+++ b/app/src/main/java/com/convergencelabstfx/smartdrone/Utility/DroneLog.java
@@ -17,7 +17,13 @@ public class DroneLog {
      * @param       noteString String; string of notes.
      */
     public static void noteList(String noteString) {
-        Log.d(NOTE_LIST, noteString);
+        try {
+            Log.d(NOTE_LIST, noteString);
+        }
+        catch(java.util.ConcurrentModificationException exception) {
+            System.out.println(exception.toString());
+        }
+
     }
 
     /**


### PR DESCRIPTION
Bug occurred due to log error. For debugging purposes I logged the list of active notes every time a note was 1) added, or 2) removed. Since notes are removed by scheduling a timer, sometimes a note would be removed while the list was building a string, causing an error.